### PR TITLE
build only when current project has changes

### DIFF
--- a/src/main/java/hudson/plugins/downstream_ext/DownstreamDependency.java
+++ b/src/main/java/hudson/plugins/downstream_ext/DownstreamDependency.java
@@ -7,6 +7,7 @@ import hudson.model.Cause;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.DependencyGraph.Dependency;
+import hudson.scm.ChangeLogSet;
 import hudson.scm.PollingResult;
 import hudson.util.LogTaskListener;
 import hudson.util.StreamTaskListener;
@@ -44,7 +45,23 @@ public class DownstreamDependency extends Dependency {
 		PrintStream logger = listener.getLogger();
 		if(trigger.getStrategy().evaluate(trigger.getThreshold(), build.getResult())) {
             AbstractProject p = getDownstreamProject();
-                
+
+            // check whether local changes are needed or not
+            if (trigger.isOnlyIfLocalSCMChanges())
+            {
+                // check whether current build is triggered by SCM - then there should be changes
+                ChangeLogSet changes = build.getChangeSet();
+                if (changes.isEmptySet())
+                {
+                    // no changes - no downstream builds
+                    logger.println(Messages.DownstreamTrigger_NoSCMChanges(build.getProject().getName()));
+                    return false;
+                }
+            }
+
+            // we either have local changes now, or they are not needed
+            // in both cases we continue with the downstream SCM check
+
             if(trigger.isOnlyIfSCMChanges()) {
             	if (p.getScm().requiresWorkspaceForPolling()) {
             		// Downstream project locks workspace while building.

--- a/src/main/java/hudson/plugins/downstream_ext/DownstreamTrigger.java
+++ b/src/main/java/hudson/plugins/downstream_ext/DownstreamTrigger.java
@@ -92,6 +92,8 @@ public class DownstreamTrigger extends Notifier implements DependecyDeclarer, Ma
     
     private final boolean onlyIfSCMChanges;
 
+    private final boolean onlyIfLocalSCMChanges;
+
     /**
      * Defines if for Matrix jobs the downstream job should only be triggered once.
      * Default is to trigger for each child configuration of the Matrix parent.
@@ -114,21 +116,22 @@ public class DownstreamTrigger extends Notifier implements DependecyDeclarer, Ma
     	new ConcurrentHashMap<AbstractProject<?,?>, Executor>();
 
     @DataBoundConstructor
-    public DownstreamTrigger(String childProjects, String threshold, boolean onlyIfSCMChanges,
+    public DownstreamTrigger(String childProjects, String threshold, boolean onlyIfSCMChanges, boolean onlyIfLocalSCMChanges,
             String strategy, String matrixTrigger) {
-        this(childProjects, resultFromString(threshold), onlyIfSCMChanges, Strategy.valueOf(strategy),
+        this(childProjects, resultFromString(threshold), onlyIfSCMChanges, onlyIfLocalSCMChanges,Strategy.valueOf(strategy),
              matrixTrigger != null ?
         		MatrixTrigger.valueOf(matrixTrigger)
         		: null);
     }
 
-    public DownstreamTrigger(String childProjects, Result threshold, boolean onlyIfSCMChanges,
+    public DownstreamTrigger(String childProjects, Result threshold, boolean onlyIfSCMChanges, boolean onlyIfLocalSCMChanges,
             Strategy strategy, MatrixTrigger matrixTrigger) {
         if(childProjects==null)
             throw new IllegalArgumentException();
         this.childProjects = childProjects;
         this.threshold = threshold;
         this.onlyIfSCMChanges = onlyIfSCMChanges;
+        this.onlyIfLocalSCMChanges = onlyIfLocalSCMChanges;
         this.thresholdStrategy = strategy;
         this.matrixTrigger = matrixTrigger;
     }
@@ -158,7 +161,12 @@ public class DownstreamTrigger extends Notifier implements DependecyDeclarer, Ma
     public boolean isOnlyIfSCMChanges() {
     	return onlyIfSCMChanges;
     }
-    
+
+    public boolean isOnlyIfLocalSCMChanges()
+    {
+        return onlyIfLocalSCMChanges;
+    }
+
     public MatrixTrigger getMatrixTrigger() {
        	return this.matrixTrigger;
     }
@@ -312,7 +320,8 @@ public class DownstreamTrigger extends Notifier implements DependecyDeclarer, Ma
 			return new DownstreamTrigger(formData.getString("childProjects"),
 					formData.getString("threshold"),
 					formData.has("onlyIfSCMChanges") && formData.getBoolean("onlyIfSCMChanges"),
-					formData.getString("strategy"),
+                    formData.has("onlyIfLocalSCMChanges") && formData.getBoolean("onlyIfLocalSCMChanges"),
+                    formData.getString("strategy"),
 					matrixTrigger
 					);
         }

--- a/src/main/resources/hudson/plugins/downstream_ext/DownstreamTrigger/config.jelly
+++ b/src/main/resources/hudson/plugins/downstream_ext/DownstreamTrigger/config.jelly
@@ -43,7 +43,12 @@ THE SOFTWARE.
       <f:checkbox id="downstreamTrigger.onlyIfSCMChanges" name="downstreamTrigger.onlyIfSCMChanges" checked="${instance.onlyIfSCMChanges}" />
       <label class="attach-previous">${%Trigger only if downstream project has SCM changes}</label>
   </f:entry>
-  <j:if test="${descriptor.isMatrixProject(it)}">
+    <f:entry title="">
+        <f:checkbox id="downstreamTrigger.onlyIfLocalSCMChanges" name="downstreamTrigger.onlyIfLocalSCMChanges"
+                    checked="${instance.onlyIfLocalSCMChanges}"/>
+        <label class="attach-previous">${%Trigger only if current project has SCM changes}</label>
+    </f:entry>
+    <j:if test="${descriptor.isMatrixProject(it)}">
 	  <f:entry title="${%Trigger for matrix projects}" help="/plugin/downstream-ext/help-matrixtrigger.html">
 	      <select name="descriptor.matrixTrigger">
 	       <j:forEach var="mTrig" items="${descriptor.MATRIX_TRIGGER_VALUES}">

--- a/src/main/resources/hudson/plugins/downstream_ext/DownstreamTrigger/config_de.properties
+++ b/src/main/resources/hudson/plugins/downstream_ext/DownstreamTrigger/config_de.properties
@@ -24,3 +24,4 @@ Projects\ to\ build=Zu bauende Projekte
 Build\ result\ is=Build-Ergebnis ist
 Trigger\ downstream\ job\ if\ build\ result\ meets\ condition=Löse nachgelagertes Projekt aus, falls das Build-Ergebnis der Bedingung entspricht
 Trigger\ only\ if\ downstream\ project\ has\ SCM\ changes=Nur Auslösen falls nachgelagertes Projekt SCM Änderungen hat.
+Trigger\ only\ if\ current\ project\ has\ SCM\ changes=Nur Auslösen falls aktuelles Projekt SCM Änderungen hat.

--- a/src/main/webapp/help.html
+++ b/src/main/webapp/help.html
@@ -13,6 +13,7 @@
   		<li>ABORTED</li>
   	</ul>
   	</li>
-  	<li>SCM changes: only triggers if the other project has SCM changes since its last build.</li>
+  	<li>Downstream SCM changes: only triggers if the other project has SCM changes since its last build.</li>
+  	<li>Local SCM changes: only triggers if the current project has SCM changes since its last build.</li>
   </ul>
 </div>

--- a/src/test/java/hudson/plugins/downstream_ext/AsynchPollingTest.java
+++ b/src/test/java/hudson/plugins/downstream_ext/AsynchPollingTest.java
@@ -71,7 +71,7 @@ public class AsynchPollingTest {
 		final Cause[] causeHolder = new Cause[1];
 		
 		DownstreamDependency dependency = new DownstreamDependency(upstream, downstream,
-				new DownstreamTrigger("", Result.SUCCESS, true, Strategy.AND_HIGHER,
+				new DownstreamTrigger("", Result.SUCCESS, true, false, Strategy.AND_HIGHER,
 						MatrixTrigger.BOTH)) {
 
 					@Override
@@ -81,7 +81,6 @@ public class AsynchPollingTest {
 						final Runnable run = super.getPoller(p, cause, actions);
 						
 						return new Runnable() {
-							@Override
 							public void run() {
 								startLatch.countDown();
 								run.run();
@@ -118,7 +117,7 @@ public class AsynchPollingTest {
 		final CountDownLatch endLatch1 = new CountDownLatch(1);
 		
 		DownstreamDependency dependency = new DownstreamDependency(upstream, downstream,
-				new DownstreamTrigger("", Result.SUCCESS, true, Strategy.AND_HIGHER,
+				new DownstreamTrigger("", Result.SUCCESS, true, false, Strategy.AND_HIGHER,
 						MatrixTrigger.BOTH)) {
 
 					@Override
@@ -127,7 +126,6 @@ public class AsynchPollingTest {
 						final Runnable run = super.getPoller(p, cause, actions);
 						
 						return new Runnable() {
-							@Override
 							public void run() {
 								startLatch1.countDown();
 								run.run();
@@ -153,7 +151,7 @@ public class AsynchPollingTest {
 		final CountDownLatch startLatch2 = new CountDownLatch(1);
 		
 		DownstreamDependency dependency2 = new DownstreamDependency(upstream, downstream,
-				new DownstreamTrigger("", Result.SUCCESS, true, Strategy.AND_HIGHER,
+				new DownstreamTrigger("", Result.SUCCESS, true, false,Strategy.AND_HIGHER,
 						MatrixTrigger.BOTH)) {
 					@Override
 					Runnable getPoller(AbstractProject p, Cause cause,
@@ -161,7 +159,6 @@ public class AsynchPollingTest {
 						final Runnable run = super.getPoller(p, cause, actions);
 						
 						return new Runnable() {
-							@Override
 							public void run() {
 								startLatch2.countDown();
 								run.run();
@@ -180,7 +177,7 @@ public class AsynchPollingTest {
 		final CountDownLatch startLatch3 = new CountDownLatch(1);
 		AbstractProject newDownstream = createDownstreamProject();
 		DownstreamDependency dependency3 = new DownstreamDependency(upstream, newDownstream,
-				new DownstreamTrigger("", Result.SUCCESS, true, Strategy.AND_HIGHER,
+				new DownstreamTrigger("", Result.SUCCESS, true, false, Strategy.AND_HIGHER,
 						MatrixTrigger.BOTH)) {
 					@Override
 					Runnable getPoller(AbstractProject p, Cause cause,
@@ -188,7 +185,6 @@ public class AsynchPollingTest {
 						final Runnable run = super.getPoller(p, cause, actions);
 						
 						return new Runnable() {
-							@Override
 							public void run() {
 								startLatch3.countDown();
 								run.run();


### PR DESCRIPTION
I have added a new configuration option. It builds the downstream jobs only when the current project has SCM changes. This allows to check whether the local changes affect the dependent jobs, but avoids to rebuild the whole dependency chain.
