### PR TITLE
regex pattern in project names

### DIFF
--- a/src/main/java/hudson/plugins/downstream_ext/DownstreamTrigger.java
+++ b/src/main/java/hudson/plugins/downstream_ext/DownstreamTrigger.java
@@ -156,6 +156,9 @@ public class DownstreamTrigger extends Notifier implements DependecyDeclarer, Ma
     }
 
     private String resolveRegex(String projects) {
+        if (Jenkins.getInstance() == null) {
+            return projects;
+        }
         List<String> providedList = Arrays.asList(projects.split(","));
         List<String> projectsList = new ArrayList<String>();
         for (String name : providedList) {


### PR DESCRIPTION
User can specify regex pattern in downstream projects name. Each name
is expanded to all its matching projects. This is particularly useful
for large projects where single project could have many dependencies.
