### PR TITLE
[JENKINS-74200] Migrate legacy checkUrl attribute

### DIFF
--- a/src/main/resources/hudson/plugins/downstream_ext/DownstreamTrigger/config.jelly
+++ b/src/main/resources/hudson/plugins/downstream_ext/DownstreamTrigger/config.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="${%Projects to build}" field="childProjects">
 	<f:textbox value="${instance.childProjectsValue}"
-               checkUrl="'descriptorByName/DownstreamTrigger/check?value='+encodeURIComponent(this.value)"/>
+               checkUrl="descriptorByName/DownstreamTrigger/check" checkDependsOn=""/>
   </f:entry>
   <f:entry title="${%Build result is}" description="${%Trigger downstream job if build result meets condition}">
      <select name="descriptor.strategy">


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

[JENKINS-74200](https://issues.jenkins.io/browse/JENKINS-74200)

**WHY**
https://www.jenkins.io/doc/developer/security/csp/#legacy-javascript-checkurl-validation

### Testing done

BEFORE CHANGES:

https://github.com/user-attachments/assets/ea139baf-844f-4a60-811c-7441dfc383b9

AFTER CHANGES

https://github.com/user-attachments/assets/d65ec952-b45c-4e83-b917-77221f6d0a39




<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
